### PR TITLE
[CALCITE-2510] [core] Add CHR built-in function (Oracle only)

### DIFF
--- a/core/src/main/codegen/templates/Parser.jj
+++ b/core/src/main/codegen/templates/Parser.jj
@@ -5528,7 +5528,6 @@ SqlPostfixOperator PostfixRowOperator() :
 |   < CHARACTERISTICS: "CHARACTERISTICS" >
 |   < CHARACTERS: "CHARACTERS" >
 |   < CHECK: "CHECK" >
-|   < CHR: "CHR" >
 |   < CLASSIFIER: "CLASSIFIER" >
 |   < CLASS_ORIGIN: "CLASS_ORIGIN" >
 |   < CLOB: "CLOB" >
@@ -6164,7 +6163,6 @@ String CommonNonReservedKeyWord() :
     |   <CHARACTER_SET_SCHEMA>
     |   <CHARACTERISTICS>
     |   <CHARACTERS>
-    |   <CHR>
     |   <CLASS_ORIGIN>
     |   <COBOL>
     |   <COLLATION>

--- a/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
+++ b/core/src/main/java/org/apache/calcite/adapter/enumerable/RexImpTable.java
@@ -89,7 +89,7 @@ import static org.apache.calcite.linq4j.tree.ExpressionType.NotEqual;
 import static org.apache.calcite.linq4j.tree.ExpressionType.OrElse;
 import static org.apache.calcite.linq4j.tree.ExpressionType.Subtract;
 import static org.apache.calcite.linq4j.tree.ExpressionType.UnaryPlus;
-import static org.apache.calcite.sql.fun.OracleSqlOperatorTable.CHR;
+import static org.apache.calcite.sql.fun.OracleSqlOperatorTable.ORACLE_CHR;
 import static org.apache.calcite.sql.fun.OracleSqlOperatorTable.TRANSLATE3;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ABS;
 import static org.apache.calcite.sql.fun.SqlStdOperatorTable.ACOS;
@@ -281,7 +281,7 @@ public class RexImpTable {
     defineUnary(UNARY_MINUS, Negate, NullPolicy.STRICT);
     defineUnary(UNARY_PLUS, UnaryPlus, NullPolicy.STRICT);
 
-    defineMethod(CHR, "chr", NullPolicy.STRICT);
+    defineMethod(ORACLE_CHR, "chr", NullPolicy.STRICT);
     defineMethod(MOD, "mod", NullPolicy.STRICT);
     defineMethod(EXP, "exp", NullPolicy.STRICT);
     defineMethod(POWER, "power", NullPolicy.STRICT);

--- a/core/src/main/java/org/apache/calcite/rex/RexSqlStandardConvertletTable.java
+++ b/core/src/main/java/org/apache/calcite/rex/RexSqlStandardConvertletTable.java
@@ -108,7 +108,7 @@ public class RexSqlStandardConvertletTable
     registerEquivOp(SqlStdOperatorTable.LOWER);
     registerEquivOp(SqlStdOperatorTable.INITCAP);
 
-    registerEquivOp(OracleSqlOperatorTable.CHR);
+    registerEquivOp(OracleSqlOperatorTable.ORACLE_CHR);
     registerEquivOp(SqlStdOperatorTable.POWER);
     registerEquivOp(SqlStdOperatorTable.SQRT);
     registerEquivOp(SqlStdOperatorTable.MOD);

--- a/core/src/main/java/org/apache/calcite/sql/fun/OracleSqlOperatorTable.java
+++ b/core/src/main/java/org/apache/calcite/sql/fun/OracleSqlOperatorTable.java
@@ -109,7 +109,7 @@ public class OracleSqlOperatorTable extends ReflectiveSqlOperatorTable {
           OperandTypes.SAME_VARIADIC, SqlFunctionCategory.SYSTEM);
 
   /** The "CHR(value)" function. */
-  public static final SqlFunction CHR =
+  public static final SqlFunction ORACLE_CHR =
       new SqlFunction(
           "CHR",
           SqlKind.OTHER_FUNCTION,

--- a/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
+++ b/core/src/test/java/org/apache/calcite/sql/test/SqlOperatorBaseTest.java
@@ -5639,7 +5639,7 @@ public abstract class SqlOperatorBaseTest {
   }
 
   @Test public void testChr() {
-    tester.setFor(OracleSqlOperatorTable.CHR, VM_FENNEL, VM_JAVA);
+    tester.setFor(OracleSqlOperatorTable.ORACLE_CHR, VM_FENNEL, VM_JAVA);
     final SqlTester tester1 = oracleTester();
     tester1.checkScalar("chr(97)",
         "a", "CHAR(1) NOT NULL");

--- a/site/_docs/reference.md
+++ b/site/_docs/reference.md
@@ -365,7 +365,6 @@ CHARACTER_SET_NAME,
 CHARACTER_SET_SCHEMA,
 **CHAR_LENGTH**,
 **CHECK**,
-CHR,
 **CLASSIFIER**,
 CLASS_ORIGIN,
 **CLOB**,
@@ -1172,7 +1171,7 @@ comp:
 | SUBSTRING(string FROM integer)  | Returns a substring of a character string starting at a given point
 | SUBSTRING(string FROM integer FOR integer) | Returns a substring of a character string starting at a given point with a given length
 | INITCAP(string)            | Returns *string* with the first letter of each word converter to upper case and the rest to lower case. Words are sequences of alphanumeric characters separated by non-alphanumeric characters.
-| CHR(numeric)               | CHR returns the character having the binary equivalent to n as a VARCHAR2 value in the database character set
+| CHR(numeric)               | CHR returns the character having the binary equivalent to n as a CHAR value in the database character set. This function has Oracle semantics.
 
 Not implemented:
 


### PR DESCRIPTION
* Function renamed in `OracleSqlOperatorTable`.
* CHR removed from `Parser.jj`.
* VARCHAR2 removed from `reference.md`.